### PR TITLE
Fix for deadlock issue #3682 

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -151,7 +151,6 @@ func max(a, b int) int {
 func (a *Alerts) Subscribe() provider.AlertIterator {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
-
 	var (
 		done   = make(chan struct{})
 		alerts = a.alerts.List()

--- a/store/store.go
+++ b/store/store.go
@@ -71,8 +71,6 @@ func (a *Alerts) Run(ctx context.Context, interval time.Duration) {
 
 func (a *Alerts) gc() {
 	a.Lock()
-	defer a.Unlock()
-
 	var resolved []*types.Alert
 	for fp, alert := range a.c {
 		if alert.Resolved() {
@@ -80,6 +78,7 @@ func (a *Alerts) gc() {
 			resolved = append(resolved, alert)
 		}
 	}
+	a.Unlock()
 	a.cb(resolved)
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR is a fix for #3682. In some instances, `mem.Alerts.Subscribe()` and `store.gc()` can get deadlocked

1. Lock acquisition in `store.Alerts.gc()`:
      - The method `store.Alerts.gc()` acquires a lock on its internal mutex `store.Alerts.mtx`
      - While holding the lock, it then calls the callback function which will try to acquire a lock on `mem.Alerts.mtx`
2. Concurrent Execution:
      -  `mem.Alerts.Subscribe()` acquires a lock on its internal mutex `mem.Alerts.mtx` and calls `store.Alerts.List()`
3. Deadlock situation:
      - Callback function tries to acquire a lock on `mem.Alerts.mtx`. However this lock is already being held by `mem.Subscribe()`
      - Similarly `mem.Subscribe()` cannot proceed because `store.List()` cannot acquire lock (`store.Alerts.mtx`) because it is being held by `store.gc()`

Another way of summarizing this is `store.Alerts.gc()` was holding the lock until callback function completed which in turn was waiting to acquire the lock. Callback function could not acquire the lock because `Subscribe()` was holding the lock. `Subscribe()` cannot progress because it calls `store.Alerts.List()` which was waiting for lock acquisition which was being held by `store.Alerts.gc()`. This fix releases the lock held by `store.Alerts.gc()` prior to calling the callback function