### PR TITLE
Changes related to reducing lock contention

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -262,9 +262,6 @@ func (a *Alerts) Put(alerts ...*types.Alert) error {
 
 // count returns the number of non-resolved alerts we currently have stored filtered by the provided state.
 func (a *Alerts) count(state types.AlertState) int {
-	a.mtx.Lock()
-	defer a.mtx.Unlock()
-
 	var count int
 	for _, alert := range a.alerts.List() {
 		if alert.Resolved() {


### PR DESCRIPTION
- The `func (a *Alerts) count(state types.AlertState) int {` in mem.go acquires a lock which is unnecessary. The count method makes a copy of the alerts by called `a.alerts.List()`. Therefore this lock can be safely removed

<img width="2465" alt="Screenshot 2025-04-10 at 7 35 47 PM" src="https://github.com/user-attachments/assets/f3d975b2-5013-434a-a107-74bca2600c41" />
